### PR TITLE
Move from SSL to internal service only

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -32,6 +32,7 @@
           - "r-base"
           - "r-base-dev"
           - "libxml2-dev"
+          - "nginx"
         state: present
 
     - name: Download RStudio Server
@@ -40,30 +41,12 @@
     - name: Install RStudio Server
       command: dpkg -i /tmp/rstudio.deb
 
-    # - name: Generate a priv key
-    #   openssl_privatekey:
-    #     path: /etc/rstudio/packer-rstudio.pem
-
-    # - name: Generate CSR
-    #   openssl_csr:
-    #     path: /etc/rstudio/packer-rstudio.csr
-    #     privatekey_path: /etc/rstudio/packer-rstudio.pem
-    #     common_name: packer-rstudio.scipoolprod.org #This DNS name does not exist
-
-    # - name: Generate a self-signed cert
-    #   openssl_certificate:
-    #     path: /etc/rstudio/packer-rstudio.cert
-    #     privatekey_path: /etc/rstudio/packer-rstudio.pem
-    #     csr_path: /etc/rstudio/packer-rstudio.csr
-    #     provider: selfsigned
-
-    # - name: Overwrite rstudio web config
-    #   copy:
-    #     dest: /etc/rstudio/rserver.conf
-    #     content: |
-    #       ssl-enabled=1
-    #       ssl-certificate=/etc/rstudio/packer-rstudio.cert
-    #       ssl-certificate-key=/etc/rstudio/packer-rstudio.pem
+    - name: Overwrite rstudio web config
+      copy:
+        dest: /etc/rstudio/rserver.conf
+        content: |
+          www-address=127.0.0.1  #Only serve on internal interface
+          www-port=8787
 
     # Install essential R packages
     - name: Install synapser

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -32,7 +32,6 @@
           - "r-base"
           - "r-base-dev"
           - "libxml2-dev"
-          - "nginx"
         state: present
 
     - name: Download RStudio Server


### PR DESCRIPTION
This removes the SSL cert and server config, but runs rstudio to accept internal connections only. Connections will have to tunnel after local auth.
