### PR TITLE
SC-135 front rstudio with local proxy

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -74,27 +74,9 @@
 
     - name: Add config for local fwd proxy to rstudio
       copy:
-        dest: /etc/nginx/conf.d/rstudio.conf
-        content: |
-          server {
-            listen 443 ssl;
-            ssl_certificate /etc/nginx/ssl/rstudio.cert;
-            ssl_certificate_key /etc/nginx/ssl/rstudio.pem;
-            location / {
-              proxy_pass http://localhost:8787/;
-              proxy_redirect http://localhost:8787/ $scheme://$host/;
-              proxy_http_version 1.1;
-              proxy_set_header Upgrade $http_upgrade;
-              proxy_set_header Connection $connection_upgrade;
-              proxy_read_timeout 20d;
-            }
-          }
-
-    - name: Add general nginx config
-      copy:
         dest: /etc/nginx/nginx.conf
         content: |
-          user nginx;
+          user www-data;  #default web server user on Ubuntu
           worker_processes auto;
           error_log /var/log/nginx/error.log;
           pid /var/run/nginx.pid;
@@ -120,7 +102,25 @@
             include             /etc/nginx/mime.types;
             default_type        application/octet-stream;
 
-            include /etc/nginx/conf.d/rstudio.conf;
+            server {
+              listen 443 ssl;
+              ssl_certificate /etc/nginx/ssl/rstudio.cert;
+              ssl_certificate_key /etc/nginx/ssl/rstudio.pem;
+
+              location / {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_pass http://localhost:8787/;
+                proxy_redirect http://localhost:8787/ $scheme://$host/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_read_timeout 7d;
+              }
+            }
+
             index   index.html index.htm;
             server_names_hash_bucket_size 128;
 

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -61,7 +61,7 @@
         path: /etc/nginx/ssl/rstudio.csr
         privatekey_path: /etc/nginx/ssl/rstudio.pem
         common_name: rstudio.scipoolprod.org #This DNS name does not exist
-                                                                    
+
     - name: Generate a self-signed cert
       openssl_certificate:
         path: /etc/nginx/ssl/rstudio.cert
@@ -126,7 +126,7 @@
             ''      close;
             }
           }
-    
+
     # Install essential R packages
     - name: Install synapser
       shell: "R -e \"install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))\""

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -7,7 +7,7 @@
 
     # - include_tasks: sagebio-base-ubuntu-bionic-v1.0.0.yaml
     - pause:
-        seconds: 30
+        seconds: 90 #time needed for aptitude to give up lock after boot
 
     - name: Add the CRAN apt key
       apt_key:
@@ -50,7 +50,10 @@
 
     #Create nginx proxy
     - name: Create folder for ssl certs
-      command: mkdir -p /etc/nginx/ssl
+      file: 
+        path: /etc/nginx/ssl
+        state: directory
+        mode: 0700
 
     - name: Generate a priv key
       openssl_privatekey:

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -47,7 +47,7 @@
 
     #Create nginx proxy
     - name: Create folder for ssl certs
-      file: 
+      file:
         path: /etc/nginx/ssl
         state: directory
         mode: 0700

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -146,3 +146,4 @@
 
    # - pip:
    #     name: synapseclient
+

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -146,4 +146,3 @@
 
    # - pip:
    #     name: synapseclient
-

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -2,12 +2,9 @@
   become: yes
 
   tasks:
-    # - name: Get base playbook
-    #   get_url: url=https://raw.githubusercontent.com/Sage-Bionetworks/packer-base-ubuntu-bionic/v1.0.0/src/playbook.yaml dest={{ playbook_dir }}/sagebio-base-ubuntu-bionic-v1.0.0.yaml
-
-    # - include_tasks: sagebio-base-ubuntu-bionic-v1.0.0.yaml
-    - pause:
-        seconds: 90 #time needed for aptitude to give up lock after boot
+    - name: Wait for automatic Ubuntu updates
+      become: yes
+      shell: while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;
 
     - name: Add the CRAN apt key
       apt_key:
@@ -72,16 +69,16 @@
         csr_path: /etc/nginx/ssl/rstudio.csr
         provider: selfsigned
 
-    - name: Add config for local fwd proxy to rstudio
+    - name: Add config for local rev proxy to rstudio
       copy:
         dest: /etc/nginx/nginx.conf
         content: |
-          user www-data;  #default web server user on Ubuntu
+          user www-data;  #default web server user on Ubuntu (should be nginx for rpm installs)
           worker_processes auto;
           error_log /var/log/nginx/error.log;
           pid /var/run/nginx.pid;
 
-          include /usr/share/nginx/modules/*.conf
+          include /usr/share/nginx/modules/*.conf;
 
           events {
             worker_connections 1024;

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -90,7 +90,7 @@
             }
           }
 
-    - name: Add config for local fwd proxy to rstudio
+    - name: Add general nginx config
       copy:
         dest: /etc/nginx/nginx.conf
         content: |

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -32,6 +32,7 @@
           - "r-base"
           - "r-base-dev"
           - "libxml2-dev"
+          - "nginx"
         state: present
 
     - name: Download RStudio Server
@@ -47,6 +48,85 @@
           www-address=127.0.0.1  #Only serve on internal interface
           www-port=8787
 
+    #Create nginx proxy
+    - name: Create folder for ssl certs
+      command: mkdir -p /etc/nginx/ssl
+
+    - name: Generate a priv key
+      openssl_privatekey:
+        path: /etc/nginx/ssl/rstudio.pem
+
+    - name: Generate CSR
+      openssl_csr:
+        path: /etc/nginx/ssl/rstudio.csr
+        privatekey_path: /etc/nginx/ssl/rstudio.pem
+        common_name: rstudio.scipoolprod.org #This DNS name does not exist
+                                                                    
+    - name: Generate a self-signed cert
+      openssl_certificate:
+        path: /etc/nginx/ssl/rstudio.cert
+        privatekey_path: /etc/nginx/ssl/rstudio.pem
+        csr_path: /etc/nginx/ssl/rstudio.csr
+        provider: selfsigned
+
+    - name: Add config for local fwd proxy to rstudio
+      copy:
+        dest: /etc/nginx/conf.d/rstudio.conf
+        content: |
+          server {
+            listen 443 ssl;
+            ssl_certificate /etc/nginx/ssl/rstudio.cert;
+            ssl_certificate_key /etc/nginx/ssl/rstudio.pem;
+            location / {
+              proxy_pass http://localhost:8787/;
+              proxy_redirect http://localhost:8787/ $scheme://$host/;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              proxy_read_timeout 20d;
+            }
+          }
+
+    - name: Add config for local fwd proxy to rstudio
+      copy:
+        dest: /etc/nginx/nginx.conf
+        content: |
+          user nginx;
+          worker_processes auto;
+          error_log /var/log/nginx/error.log;
+          pid /var/run/nginx.pid;
+
+          include /usr/share/nginx/modules/*.conf
+
+          events {
+            worker_connections 1024;
+          }
+
+          http {
+            log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                              '$status $body_bytes_sent "$http_referer" '
+                              '"$http_user_agent" "$http_x_forwarded_for"';
+
+            access_log  /var/log/nginx/access.log  main;
+
+            sendfile            on;
+            tcp_nopush          on;
+            tcp_nodelay         on;
+            keepalive_timeout   65;
+            types_hash_max_size 2048;
+            include             /etc/nginx/mime.types;
+            default_type        application/octet-stream;
+
+            include /etc/nginx/conf.d/rstudio.conf;
+            index   index.html index.htm;
+            server_names_hash_bucket_size 128;
+
+            map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+            }
+          }
+    
     # Install essential R packages
     - name: Install synapser
       shell: "R -e \"install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))\""


### PR DESCRIPTION
This change allows fronting an rstudio install with an nginx proxy with proper forwarding of headers so that the instance can be routed to through a load balancer.
