### PR TITLE
Inc pause value to fix travis build

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -3,7 +3,7 @@
 
   tasks:
     - pause:
-        seconds: 30
+        seconds: 60
 
     - name: Add the CRAN apt key
       apt_key:


### PR DESCRIPTION
Small change to bump pause, hopefully preventing travis from tripping over the apt lock on the instance.