### PR TITLE
Revert "Attempt wait lock"

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -2,9 +2,8 @@
   become: yes
 
   tasks:
-    - name: Wait for automatic Ubuntu updates
-      become: yes
-      shell: while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 1; done;
+    - pause:
+        seconds: 60
 
     - name: Add the CRAN apt key
       apt_key:


### PR DESCRIPTION
Reverts Sage-Bionetworks-IT/packer-rstudio#27

The lock-frontend stalling didn't change the build status.