### PR TITLE
[SC-159] Install dependencies with aptdcon to avoid dpkg lock contention

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -6,8 +6,6 @@
     #   get_url: url=https://raw.githubusercontent.com/Sage-Bionetworks/packer-base-ubuntu-bionic/v1.0.0/src/playbook.yaml dest={{ playbook_dir }}/sagebio-base-ubuntu-bionic-v1.0.0.yaml
 
     # - include_tasks: sagebio-base-ubuntu-bionic-v1.0.0.yaml
-    - pause:
-        seconds: 30
 
     - name: Add the CRAN apt key
       apt_key:
@@ -20,19 +18,7 @@
         update_cache: yes
 
     - name: install packages
-      package:
-        name:
-          - "zlib1g-dev"
-          - "libclang-dev"
-          - "libssl-dev"
-          - "libffi-dev"
-          - "libcurl4-openssl-dev"
-          - "libapparmor1"
-          - "libssl1.0.0"
-          - "r-base"
-          - "r-base-dev"
-          - "libxml2-dev"
-        state: present
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb

--- a/src/template.json
+++ b/src/template.json
@@ -42,6 +42,9 @@
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'"
       ],
+      "extra_arguments": [
+        "-v"
+      ],
       "playbook_file": "playbook.yaml",
       "type": "ansible"
     }
@@ -54,7 +57,7 @@
     "OwnerEmail": "thomas.yu@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotUsers": "563295687221,055273631518,804034162148,237179673806",
-    "SourceImage": "ami-093ca9e768e56b1bc",
+    "SourceImage": "ami-09ddd854571a732be",
     "SshUsername": "ubuntu",
     "VolumeSize": "16"
   }


### PR DESCRIPTION
Uses aptdcon for installing packages to avoid apt lock contention.
Inspired by [this AskUbuntu question](https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running).

aptdcon submits requests to aptdaemon which queues them, so our request will wait instead of failing when it can't acquire a lock

Updates `SourceImage` to packer-base-ubuntu-bionic v1.0.8 (which installs aptdaemon package)