### PR TITLE
Use aptdcon to add cran repo and refresh cache

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -13,9 +13,7 @@
         id: E298A3A825C0D65DFD57CBB651716619E084DAB9
 
     - name: Add R-Project apt repository
-      apt_repository:
-        repo: deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/
-        update_cache: yes
+      shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
       shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"


### PR DESCRIPTION
This modifies another step that uses apt directly, the one that sets up the CRAN repo. Failures are sometimes encountered, and it is believe that the root cause of this is also the lock contention. Switching to use of aptdcon over the ansible apt_repository module.