### PR TITLE
Single volume instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # packer
 src/manifest.json
+
+#jetbrains
+.idea/

--- a/src/template.json
+++ b/src/template.json
@@ -8,7 +8,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/xvda",
+          "device_name": "/dev/sda1",
           "volume_size": "{{user `VolumeSize`}}",
           "volume_type": "gp2"
         }


### PR DESCRIPTION
Setting device name to "/dev/xvda" causes AWS to add an additional
volume to the instance because xvda is for awslinux.   We only want
a single root volume so we can tag it for cost tracking.
For Ubuntu the device name should be "/dev/sda1".