### PR TITLE
Local reverse proxy from ALB

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-/** @Sage-Bionetworks/sagebio-it
-
-# For creation and termination of requests which are added to config/prod
-# add other individuals who have been trained on the process here.
-config/ @Sage-Bionetworks/infra-oversight-committee
-
-# For creation and removal of templates
-templates/ @Sage-Bionetworks/infra-oversight-committee
+* @Sage-Bionetworks-IT/sagebio-it  @Sage-Bionetworks-IT/sage-image-librarians

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # packer
 src/manifest.json
+
+#jetbrains
+.idea/

--- a/src/access.py
+++ b/src/access.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import jwt
+import requests
+import base64
+import json
+import boto3
+
+from mod_python import apache
+
+region = 'us-east-1'
+
+def headerparserhandler(req):
+
+  jwt = req.headers_in['x-amzn-oidc-data'] #proxy.conf ensures this header exists
+
+  if session_user(jwt) == approved_user():
+    return apache.OK
+  else:
+    return apache.HTTP_UNAUTHORIZED #the userid claim does not match the userid tag
+
+def approved_user():
+  meta = requests.get('http://169.254.169.254/latest/meta-data/instance-id')
+  instance_id = meta.text
+
+  ec2 = boto3.resource('ec2',region)
+  vm = ec2.Instance(instance_id)
+
+  #TODO handle exception on multiple tags in this list
+  for tags in vm.tags:
+    if tags["Key"] == 'Protected/AccessApprovedCaller':
+      approved_caller = tags["Value"]
+
+  return approved_caller.split(':')[1] #return userid portion of tag
+
+def session_user(encoded_jwt):
+
+  # The x-amzn-oid-data header is a base64-encoded JWT signed by the ALB
+  # validating the signature of the JWT means the payload is authentic
+  # per http://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html
+  # Step 1: Get the key id from JWT headers (the kid field)
+  #encoded_jwt = headers.dict['x-amzn-oidc-data']
+  jwt_headers = encoded_jwt.split('.')[0]
+
+  decoded_jwt_headers = base64.b64decode(jwt_headers)
+  decoded_jwt_headers = decoded_jwt_headers.decode("utf-8")
+  decoded_json = json.loads(decoded_jwt_headers)
+  kid = decoded_json['kid']
+
+  # Step 2: Get the public key from regional endpoint
+  url = 'https://public-keys.auth.elb.' + region + '.amazonaws.com/' + kid
+  req = requests.get(url)
+  pub_key = req.text
+
+  # Step 3: Get the payload
+  payload = jwt.decode(encoded_jwt, pub_key, algorithms=['ES256'])
+  #TODO handle validation errors, this call validates the signature
+
+  return payload['userid']

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -16,7 +16,13 @@
       shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
-      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev apache2'"
+
+    - name: Download OAUTH2 module 
+      get_url: url=https://github.com/zmartzone/liboauth2/releases/download/v1.3.0/liboauth2_1.3.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2.deb
+
+    - name: Install OAUTH2 module Server
+      command: dpkg -i /tmp/liboauth2.deb
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb
@@ -30,101 +36,49 @@
         content: |
           www-address=127.0.0.1  #Only serve on internal interface
           www-port=8787
+          #TODO need to disable local auth
 
-    #Create nginx proxy
+    #Define apache2 proxy
     - name: Create folder for ssl certs
       file:
-        path: /etc/nginx/ssl
+        path: /etc/apache2/ssl
         state: directory
         mode: 0700
 
     - name: Generate a priv key
       openssl_privatekey:
-        path: /etc/nginx/ssl/rstudio.pem
+        path: /etc/apache2/ssl/proxy.key
 
     - name: Generate CSR
       openssl_csr:
-        path: /etc/nginx/ssl/rstudio.csr
+        path: /etc/apache2/ssl/rstudio.csr
         privatekey_path: /etc/nginx/ssl/rstudio.pem
-        common_name: rstudio.scipoolprod.org #This DNS name does not exist
+        #common_name: rstudio.sageit.org #This DNS name does not exist
 
     - name: Generate a self-signed cert
       openssl_certificate:
-        path: /etc/nginx/ssl/rstudio.cert
-        privatekey_path: /etc/nginx/ssl/rstudio.pem
-        csr_path: /etc/nginx/ssl/rstudio.csr
+        path: /etc/apache/ssl/proxy.cert
+        privatekey_path: /etc/nginx/ssl/proxy.key
+        csr_path: /etc/nginx/ssl/proxy.csr
         provider: selfsigned
 
-    - name: Add config for local rev proxy to rstudio
+    - name: Add config for local rev proxy to internal port
       copy:
-        dest: /etc/nginx/nginx.conf
-        content: |
-          user www-data;  #default web server user on Ubuntu (should be nginx for rpm installs)
-          worker_processes auto;
-          error_log /var/log/nginx/error.log;
-          pid /var/run/nginx.pid;
-
-          include /usr/share/nginx/modules/*.conf;
-
-          events {
-            worker_connections 1024;
-          }
-
-          http {
-            log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                              '$status $body_bytes_sent "$http_referer" '
-                              '"$http_user_agent" "$http_x_forwarded_for"';
-
-            access_log  /var/log/nginx/access.log  main;
-
-            sendfile            on;
-            tcp_nopush          on;
-            tcp_nodelay         on;
-            keepalive_timeout   65;
-            types_hash_max_size 2048;
-            include             /etc/nginx/mime.types;
-            default_type        application/octet-stream;
-
-            server {
-              listen 443 ssl;
-              ssl_certificate /etc/nginx/ssl/rstudio.cert;
-              ssl_certificate_key /etc/nginx/ssl/rstudio.pem;
-
-              location / {
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_pass http://localhost:8787/;
-                proxy_redirect http://localhost:8787/ $scheme://$host/;
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection $connection_upgrade;
-                proxy_read_timeout 7d;
-              }
-            }
-
-            index   index.html index.htm;
-            server_names_hash_bucket_size 128;
-
-            map $http_upgrade $connection_upgrade {
-            default upgrade;
-            ''      close;
-            }
-          }
+        src: proxy.conf
+        dest: /etc/apache2/sites-enabled/proxy.conf
 
     # Install essential R packages
     - name: Install synapser
       shell: "R -e \"install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))\""
 
-    - name: Install tidyverse
-      shell: "R -e \"install.packages('tidyverse')\""
+   #- name: Install tidyverse
+   #  shell: "R -e \"install.packages('tidyverse')\""
 
-    - name: Install devtools
-      shell: "R -e \"install.packages('devtools')\""
+   #- name: Install devtools
+   #  shell: "R -e \"install.packages('devtools')\""
 
-    - name: Install BiocManager
-      shell: "R -e \"install.packages('BiocManager')\""
+   #- name: Install BiocManager
+   #  shell: "R -e \"install.packages('BiocManager')\""
 
    # reticulate has python path issues
    # - name: Install reticulate

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -6,8 +6,6 @@
     #   get_url: url=https://raw.githubusercontent.com/Sage-Bionetworks/packer-base-ubuntu-bionic/v1.0.0/src/playbook.yaml dest={{ playbook_dir }}/sagebio-base-ubuntu-bionic-v1.0.0.yaml
 
     # - include_tasks: sagebio-base-ubuntu-bionic-v1.0.0.yaml
-    - pause:
-        seconds: 30
 
     - name: Add the CRAN apt key
       apt_key:
@@ -20,19 +18,7 @@
         update_cache: yes
 
     - name: install packages
-      package:
-        name:
-          - "zlib1g-dev"
-          - "libclang-dev"
-          - "libssl-dev"
-          - "libffi-dev"
-          - "libcurl4-openssl-dev"
-          - "libapparmor1"
-          - "libssl1.0.0"
-          - "r-base"
-          - "r-base-dev"
-          - "libxml2-dev"
-        state: present
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -48,8 +48,11 @@
     - name: Enable modules
       command: a2enmod ssl proxy proxy_http rewrite python headers
 
-    - name: Enable proxy site and disable default
-      command: a2enssite proxy && a2dissite 000-default
+    - name: Enable proxy site 
+      command: a2ensite proxy 
+
+    - name: Disable default
+      command: a2dissite 000-default
 
     # Install essential R packages
     - name: Install synapser

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -13,9 +13,7 @@
         id: E298A3A825C0D65DFD57CBB651716619E084DAB9
 
     - name: Add R-Project apt repository
-      apt_repository:
-        repo: deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/
-        update_cache: yes
+      shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
       shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -31,6 +31,11 @@
           www-address=127.0.0.1  #Only serve on internal interface
           www-port=8787
 
+    - name: Replace rstudio-server service with no auth 
+      copy:
+        src: rstudio-server.service
+        dest: /etc/systemd/system/
+
     - name: Add JWT and instance tag verifing script
       copy:
         src: access.py

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -24,7 +24,6 @@
     - name: Install RStudio Server
       command: dpkg -i /tmp/rstudio.deb
 
-      #TODO also need to overwrite systemd service definition
     - name: Overwrite rstudio web config
       copy:
         dest: /etc/rstudio/rserver.conf
@@ -58,3 +57,11 @@
     - name: Install synapser
       shell: "R -e \"install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))\""
 
+    - name: Install tidyverse
+      shell: "R -e \"install.packages('tidyverse')\""
+
+    - name: Install devtools
+      shell: "R -e \"install.packages('devtools')\""
+
+    - name: Install BiocManager
+      shell: "R -e \"install.packages('BiocManager')\""

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -13,18 +13,105 @@
         id: E298A3A825C0D65DFD57CBB651716619E084DAB9
 
     - name: Add R-Project apt repository
-      apt_repository:
-        repo: deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/
-        update_cache: yes
+      shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
-      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev nginx'"
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev'"
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb
 
     - name: Install RStudio Server
       command: dpkg -i /tmp/rstudio.deb
+
+    - name: Overwrite rstudio web config
+      copy:
+        dest: /etc/rstudio/rserver.conf
+        content: |
+          www-address=127.0.0.1  #Only serve on internal interface
+          www-port=8787
+
+    #Create nginx proxy
+    - name: Create folder for ssl certs
+      file:
+        path: /etc/nginx/ssl
+        state: directory
+        mode: 0700
+
+    - name: Generate a priv key
+      openssl_privatekey:
+        path: /etc/nginx/ssl/rstudio.pem
+
+    - name: Generate CSR
+      openssl_csr:
+        path: /etc/nginx/ssl/rstudio.csr
+        privatekey_path: /etc/nginx/ssl/rstudio.pem
+        common_name: rstudio.scipoolprod.org #This DNS name does not exist
+
+    - name: Generate a self-signed cert
+      openssl_certificate:
+        path: /etc/nginx/ssl/rstudio.cert
+        privatekey_path: /etc/nginx/ssl/rstudio.pem
+        csr_path: /etc/nginx/ssl/rstudio.csr
+        provider: selfsigned
+
+    - name: Add config for local rev proxy to rstudio
+      copy:
+        dest: /etc/nginx/nginx.conf
+        content: |
+          user www-data;  #default web server user on Ubuntu (should be nginx for rpm installs)
+          worker_processes auto;
+          error_log /var/log/nginx/error.log;
+          pid /var/run/nginx.pid;
+
+          include /usr/share/nginx/modules/*.conf;
+
+          events {
+            worker_connections 1024;
+          }
+
+          http {
+            log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                              '$status $body_bytes_sent "$http_referer" '
+                              '"$http_user_agent" "$http_x_forwarded_for"';
+
+            access_log  /var/log/nginx/access.log  main;
+
+            sendfile            on;
+            tcp_nopush          on;
+            tcp_nodelay         on;
+            keepalive_timeout   65;
+            types_hash_max_size 2048;
+            include             /etc/nginx/mime.types;
+            default_type        application/octet-stream;
+
+            server {
+              listen 443 ssl;
+              ssl_certificate /etc/nginx/ssl/rstudio.cert;
+              ssl_certificate_key /etc/nginx/ssl/rstudio.pem;
+
+              location / {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_pass http://localhost:8787/;
+                proxy_redirect http://localhost:8787/ $scheme://$host/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_read_timeout 7d;
+              }
+            }
+
+            index   index.html index.htm;
+            server_names_hash_bucket_size 128;
+
+            map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+            }
+          }
 
     # Install essential R packages
     - name: Install synapser

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -16,25 +16,7 @@
       shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
-      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev apache2 libmemcached11 libjansson4 libcjose0 libhiredis0.13 ssl-cert'"
-
-    - name: Download OAUTH2 library 
-      get_url: url=https://github.com/zmartzone/liboauth2/releases/download/v1.3.0/liboauth2_1.3.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2.deb
-
-    - name: Install OAUTH2 library 
-      command: dpkg -i /tmp/liboauth2.deb
-
-    - name: Download OAUTH2 apache2 binding 
-      get_url: url=https://github.com/zmartzone/liboauth2/releases/download/v1.3.0/liboauth2-apache_1.3.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2-apache.deb
-
-    - name: Install OAUTH2 apache2 binding 
-      command: dpkg -i /tmp/liboauth2-apache.deb
-
-    - name: Download OAUTH2 apache2 module 
-      get_url: url=https://github.com/zmartzone/mod_oauth2/releases/download/v3.1.0/libapache2-mod-oauth2_3.1.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2-apache-module.deb
-
-    - name: Install OAUTH2 apache2 module 
-      command: dpkg -i /tmp/liboauth2-apache-module.deb
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev apache2 ssl-cert libapache2-mod-python python3-boto3'"
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb
@@ -42,32 +24,32 @@
     - name: Install RStudio Server
       command: dpkg -i /tmp/rstudio.deb
 
+      #TODO also need to overwrite systemd service definition
     - name: Overwrite rstudio web config
       copy:
         dest: /etc/rstudio/rserver.conf
         content: |
           www-address=127.0.0.1  #Only serve on internal interface
           www-port=8787
-          #TODO need to disable local auth
+
+    - name: Add JWT and instance tag verifing script
+      copy:
+        src: access.py
+        dest: /usr/lib/cgi-bin/access.py
+        owner: www-data
+        group: www-data
+        mode: 0755
 
     - name: Add config for local rev proxy to internal port
       copy:
         src: proxy.conf
         dest: /etc/apache2/sites-available/proxy.conf
 
-    - name: Enable ssl proxy modules
-      command: a2enmod ssl proxy proxy_http oauth2
+    - name: Enable modules
+      command: a2enmod ssl proxy proxy_http rewrite python headers
 
-    - name: Add normal symlink convention
-      file:
-        src: /etc/apache2/site-available/proxy.conf
-        dest: /etc/apache2/sites-enabled/proxy.conf
-        state: link
-
-    - name: Remove default enabled site
-      file:
-        src: /etc/apache2/sites-enabled/000-default.conf
-        state: absent
+    - name: Enable proxy site and disable default
+      command: a2enssite proxy && a2dissite 000-default
 
     # Install essential R packages
     - name: Install synapser

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -16,13 +16,25 @@
       shell: "aptdcon --add-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran35/' && aptdcon --refresh"
 
     - name: install packages
-      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev apache2'"
+      shell: "yes | aptdcon --hide-terminal --install 'zlib1g-dev libclang-dev libssl-dev libffi-dev libcurl4-openssl-dev libapparmor1 libssl1.0.0 r-base r-base-dev libxml2-dev apache2 libmemcached11 libjansson4 libcjose0 libhiredis0.13 ssl-cert'"
 
-    - name: Download OAUTH2 module 
+    - name: Download OAUTH2 library 
       get_url: url=https://github.com/zmartzone/liboauth2/releases/download/v1.3.0/liboauth2_1.3.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2.deb
 
-    - name: Install OAUTH2 module Server
+    - name: Install OAUTH2 library 
       command: dpkg -i /tmp/liboauth2.deb
+
+    - name: Download OAUTH2 apache2 binding 
+      get_url: url=https://github.com/zmartzone/liboauth2/releases/download/v1.3.0/liboauth2-apache_1.3.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2-apache.deb
+
+    - name: Install OAUTH2 apache2 binding 
+      command: dpkg -i /tmp/liboauth2-apache.deb
+
+    - name: Download OAUTH2 apache2 module 
+      get_url: url=https://github.com/zmartzone/mod_oauth2/releases/download/v3.1.0/libapache2-mod-oauth2_3.1.0-1.bionic+1_amd64.deb dest=/tmp/liboauth2-apache-module.deb
+
+    - name: Install OAUTH2 apache2 module 
+      command: dpkg -i /tmp/liboauth2-apache-module.deb
 
     - name: Download RStudio Server
       get_url: url=https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5033-amd64.deb dest=/tmp/rstudio.deb
@@ -38,51 +50,26 @@
           www-port=8787
           #TODO need to disable local auth
 
-    #Define apache2 proxy
-    - name: Create folder for ssl certs
-      file:
-        path: /etc/apache2/ssl
-        state: directory
-        mode: 0700
-
-    - name: Generate a priv key
-      openssl_privatekey:
-        path: /etc/apache2/ssl/proxy.key
-
-    - name: Generate CSR
-      openssl_csr:
-        path: /etc/apache2/ssl/rstudio.csr
-        privatekey_path: /etc/nginx/ssl/rstudio.pem
-        #common_name: rstudio.sageit.org #This DNS name does not exist
-
-    - name: Generate a self-signed cert
-      openssl_certificate:
-        path: /etc/apache/ssl/proxy.cert
-        privatekey_path: /etc/nginx/ssl/proxy.key
-        csr_path: /etc/nginx/ssl/proxy.csr
-        provider: selfsigned
-
     - name: Add config for local rev proxy to internal port
       copy:
         src: proxy.conf
+        dest: /etc/apache2/sites-available/proxy.conf
+
+    - name: Enable ssl proxy modules
+      command: a2enmod ssl proxy proxy_http oauth2
+
+    - name: Add normal symlink convention
+      file:
+        src: /etc/apache2/site-available/proxy.conf
         dest: /etc/apache2/sites-enabled/proxy.conf
+        state: link
+
+    - name: Remove default enabled site
+      file:
+        src: /etc/apache2/sites-enabled/000-default.conf
+        state: absent
 
     # Install essential R packages
     - name: Install synapser
       shell: "R -e \"install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))\""
 
-   #- name: Install tidyverse
-   #  shell: "R -e \"install.packages('tidyverse')\""
-
-   #- name: Install devtools
-   #  shell: "R -e \"install.packages('devtools')\""
-
-   #- name: Install BiocManager
-   #  shell: "R -e \"install.packages('BiocManager')\""
-
-   # reticulate has python path issues
-   # - name: Install reticulate
-   #   shell: "R -e \"install.packages('reticulate')\""
-
-   # - pip:
-   #     name: synapseclient

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -1,14 +1,12 @@
- uses this module: https://github.com/zmartzone/mod_auth_openidc
-# documented here: https://github.com/zmartzone/mod_oauth2/blob/master/oauth2.conf
-#LoadFile "/usr/lib/x86_64-linux-gnu/liboauth2_apache.so"
-#LoadModule oauth2_module liboauth2_apache
-
 <VirtualHost *:443>
     SSLEngine On
-    SSLCertificateFile /etc/apache2/ssl/proxy.crt
-    SSLCertificateKeyFile /etc/apache2/ssl/proxy.key
+    SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 
-#    ProxyRequests Off
+#   RewriteEngine On
+#   RewriteRule ^/postauth*$ /[R]
+
+    ProxyRequests On
     ProxyPreserveHost On
 
 #    OIDCProviderUserInfoEndpoint    https://repo-prod.prod.sagebase.org/auth/v1/userinfo
@@ -21,16 +19,25 @@
 #    OIDCRemoteUserClaim userid
 #    OIDCHTTPTimeoutLong 5
 
-  <Location />
-    AuthType oauth2
-    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
-    Require valid-user
-    Require claim userid:${APPROVED_USER}
+  <Proxy "*">
+     AuthType oauth2
+#    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
+     OAuth2TokenVerify eckey_uri https://public-keys.auth.elb.us-east-1.amazonaws.com/kid
+#    Require valid-user
+     OAuth2TargetPass remote_user_claim=userid
+#    Require claim userid:${APPROVED_USER}
+  </Proxy>
+
+#  <Location />
+#    AuthType oauth2
+#    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
+#    Require valid-user
+#    Require claim userid:${APPROVED_USER}
 #APPROVED_USER is a variable in ../envvars
 #REMOTE_USER is set by the OAuth introspection
 #    Require ${REMOTE_USER} ${APPROVED_USER}
-    ProxyPass http://localhost:8787/
-    ProxyPassReverse http://localhost:8787/
-  </Location>
+    ProxyPass /postauth/ http://localhost:8787/
+    ProxyPassReverse /postauth/ http://localhost:8787/
+#  </Location>
 
 </VirtualHost>

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -1,43 +1,31 @@
-<VirtualHost *:443>
-    SSLEngine On
-    SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
-    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+<VirtualHost _default_:443>
+  ServerName proxy.localhost
 
-#   RewriteEngine On
-#   RewriteRule ^/postauth*$ /[R]
+  SSLEngine On
+  SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
+  SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 
-    ProxyRequests On
-    ProxyPreserveHost On
+  ProxyRequests Off
+  ProxyPreserveHost On
 
-#    OIDCProviderUserInfoEndpoint    https://repo-prod.prod.sagebase.org/auth/v1/userinfo
-#    OIDCCryptoPassphrase secretstring
-#    OIDCRedirectURI https://localhost
-#    OIDCOAuthIntrospectionEndpointMethod    GET
-#    OIDCSSLValidateServer    Off
-#    OIDCUserInfoTokenMethod authz_header
-##    OIDCOAuthIntrospectionTokenParamName    access_token
-#    OIDCRemoteUserClaim userid
-#    OIDCHTTPTimeoutLong 5
+  #Block requests that do not have an X-Amzn-Oidc-Data header
+  RewriteEngine On
+  RewriteCond %{HTTP:X-Amzn-Oidc-Data} ^$
+  RewriteRule ^ - [F]
 
-  <Proxy "*">
-     AuthType oauth2
-#    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
-     OAuth2TokenVerify eckey_uri https://public-keys.auth.elb.us-east-1.amazonaws.com/kid
-#    Require valid-user
-     OAuth2TargetPass remote_user_claim=userid
-#    Require claim userid:${APPROVED_USER}
-  </Proxy>
+  RewriteCond %{HTTP:Upgrade} =websocket
+  RewriteRule /(.*)     ws://localhost:8787/$1  [P,L]
+  RewriteCond %{HTTP:Upgrade} !=websocket
+  RewriteRule /(.*)     http://localhost:8787/$1 [P,L]
 
-#  <Location />
-#    AuthType oauth2
-#    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
-#    Require valid-user
-#    Require claim userid:${APPROVED_USER}
-#APPROVED_USER is a variable in ../envvars
-#REMOTE_USER is set by the OAuth introspection
-#    Require ${REMOTE_USER} ${APPROVED_USER}
-    ProxyPass /postauth/ http://localhost:8787/
-    ProxyPassReverse /postauth/ http://localhost:8787/
-#  </Location>
+  Header add X-RStudio-Username "ubuntu"
 
+  <Location />    
+    AddHandler mod_python .py
+    PythonPath "sys.path+['/usr/lib/cgi-bin', 'usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/usr/local/lib/python3.6/dist-packages', '/usr/lib/python3/dist-packages']"
+    PythonHandler access
+    PythonHeaderParserHandler access
+    ProxyPass http://localhost:8787/
+    ProxyPassReverse http://localhost:8787/
+  </Location>
 </VirtualHost>

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -1,0 +1,36 @@
+ uses this module: https://github.com/zmartzone/mod_auth_openidc
+# documented here: https://github.com/zmartzone/mod_oauth2/blob/master/oauth2.conf
+#LoadFile "/usr/lib/x86_64-linux-gnu/liboauth2_apache.so"
+#LoadModule oauth2_module liboauth2_apache
+
+<VirtualHost *:443>
+    SSLEngine On
+    SSLCertificateFile /etc/apache2/ssl/proxy.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/proxy.key
+
+#    ProxyRequests Off
+    ProxyPreserveHost On
+
+#    OIDCProviderUserInfoEndpoint    https://repo-prod.prod.sagebase.org/auth/v1/userinfo
+#    OIDCCryptoPassphrase secretstring
+#    OIDCRedirectURI https://localhost
+#    OIDCOAuthIntrospectionEndpointMethod    GET
+#    OIDCSSLValidateServer    Off
+#    OIDCUserInfoTokenMethod authz_header
+##    OIDCOAuthIntrospectionTokenParamName    access_token
+#    OIDCRemoteUserClaim userid
+#    OIDCHTTPTimeoutLong 5
+
+  <Location />
+    AuthType oauth2
+    OAuth2TokenVerify metadata https://repo-prod.prod.sagebase.org/auth/v1/.well-known/openid-configuration
+    Require valid-user
+    Require claim userid:${APPROVED_USER}
+#APPROVED_USER is a variable in ../envvars
+#REMOTE_USER is set by the OAuth introspection
+#    Require ${REMOTE_USER} ${APPROVED_USER}
+    ProxyPass http://localhost:8787/
+    ProxyPassReverse http://localhost:8787/
+  </Location>
+
+</VirtualHost>

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -1,5 +1,4 @@
 <VirtualHost _default_:443>
-  ServerName proxy.localhost
 
   SSLEngine On
   SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
@@ -8,24 +7,12 @@
   ProxyRequests Off
   ProxyPreserveHost On
 
-  #Block requests that do not have an X-Amzn-Oidc-Data header
-  RewriteEngine On
-  RewriteCond %{HTTP:X-Amzn-Oidc-Data} ^$
-  RewriteRule ^ - [F]
-
-  RewriteCond %{HTTP:Upgrade} =websocket
-  RewriteRule /(.*)     ws://localhost:8787/$1  [P,L]
-  RewriteCond %{HTTP:Upgrade} !=websocket
-  RewriteRule /(.*)     http://localhost:8787/$1 [P,L]
-
-  Header add X-RStudio-Username "ubuntu"
-
-  <Location />    
+  <LocationMatch /EC2_INSTANCE_ID/>    
     AddHandler mod_python .py
     PythonPath "sys.path+['/usr/lib/cgi-bin', 'usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/usr/local/lib/python3.6/dist-packages', '/usr/lib/python3/dist-packages']"
     PythonHandler access
     PythonHeaderParserHandler access
     ProxyPass http://localhost:8787/
-    ProxyPassReverse http://localhost:8787/
-  </Location>
+    ProxyPassReverse http://localhost:8787/$0
+  </LocationMatch>
 </VirtualHost>

--- a/src/rstudio-server.service
+++ b/src/rstudio-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=RStudio Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/rstudio-server.pid
+User=ubuntu
+ExecStart=/usr/lib/rstudio-server/bin/rserver --auth-none 1
+ExecStop=/usr/bin/killall -TERM rserver
+KillMode=none
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/src/template.json
+++ b/src/template.json
@@ -8,7 +8,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/xvda",
+          "device_name": "/dev/sda1",
           "volume_size": "{{user `VolumeSize`}}",
           "volume_type": "gp2"
         }

--- a/src/template.json
+++ b/src/template.json
@@ -42,6 +42,9 @@
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'"
       ],
+      "extra_arguments": [
+        "-v"
+      ],
       "playbook_file": "playbook.yaml",
       "type": "ansible"
     }
@@ -54,7 +57,7 @@
     "OwnerEmail": "thomas.yu@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotUsers": "563295687221,055273631518,804034162148,237179673806",
-    "SourceImage": "ami-093ca9e768e56b1bc",
+    "SourceImage": "ami-09ddd854571a732be",
     "SshUsername": "ubuntu",
     "VolumeSize": "16"
   }

--- a/src/template.json
+++ b/src/template.json
@@ -54,7 +54,7 @@
     "OwnerEmail": "thomas.yu@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-09ddd854571a732be",
+    "SourceImage": "ami-0b7906ab614596e7e",
     "SshUsername": "ubuntu",
     "VolumeSize": "16"
   }

--- a/src/template.json
+++ b/src/template.json
@@ -1,8 +1,8 @@
 {
   "builders": [
     {
+      "ami_groups": "{{user `AmiGroups`}}",
       "ami_name": "{{user `ImageName`}}",
-      "ami_users": "{{user `AmiUsers`}}",
       "force_delete_snapshot": "true",
       "instance_type": "{{user `InstanceType`}}",
       "launch_block_device_mappings": [
@@ -15,7 +15,7 @@
       ],
       "profile": "{{user `AwsProfile`}}",
       "region": "{{user `AwsRegion`}}",
-      "snapshot_users": "{{user `SnapshotUsers`}}",
+      "snapshot_groups": "{{user `SnapshotGroups`}}",
       "source_ami": "{{user `SourceImage`}}",
       "ssh_username": "{{user `SshUsername`}}",
       "tags": {
@@ -50,13 +50,13 @@
     }
   ],
   "variables": {
-    "AmiUsers": "563295687221,055273631518,804034162148,237179673806",
+    "AmiGroups": "all",
     "Department": "Platform",
     "ImageName": "{{env `ImageName`}}",
     "InstanceType": "t3.small",
     "OwnerEmail": "thomas.yu@sagebase.org",
     "Project": "Infrastructure",
-    "SnapshotUsers": "563295687221,055273631518,804034162148,237179673806",
+    "SnapshotGroups": "all",
     "SourceImage": "ami-09ddd854571a732be",
     "SshUsername": "ubuntu",
     "VolumeSize": "16"


### PR DESCRIPTION
This adds an Apache proxy on HTTPS/443 that forwards traffic to the internal rstudio service, but inspects the incoming headers first.
