### PR TITLE
Remove pre-commit auto update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
   include:
     - stage: validate
       script:
-        - pre-commit autoupdate
         - pre-commit run --all-files
         - pushd src
         - echo "ImageName = ${IMAGE_NAME}"


### PR DESCRIPTION
The `.pre-commit-config.yaml` definition pegs the version tags of the repos it pulls scripts from. This change removes the auto update steps that travis runs; auto update to pre-commit pulls the most recent tag releases of the pre-commit scripts, which can include pre-release stuff and break a build.

Passes pre-commit