### PR TITLE
SC-318 set NOFILE in system.conf instead of limits.conf to ensure it …

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -95,12 +95,10 @@
 
     - name: Install BiocManager
       shell: "R -e \"install.packages('BiocManager')\""
-
-    - name: update limits.conf
-      shell:
-        cmd: |
-          # The ">>" commands won't work unless we make this permission change
-          sudo chmod 666 /etc/security/limits.conf
-          echo '* soft nofile 1000000' >> /etc/security/limits.conf
-          echo '* hard nofile 1000000' >> /etc/security/limits.conf
-          sudo chmod 644 /etc/security/limits.conf
+      
+    - name: Update file access limits for all processes
+      copy: 
+        dest: /etc/systemd/system.conf.d/60-DefaultLimitNOFILE.conf
+        content: |
+          [Manager]
+          DefaultLimitNOFILE=1000000

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -95,7 +95,7 @@
 
     - name: Install BiocManager
       shell: "R -e \"install.packages('BiocManager')\""
-      
+
     - name: Update file access limits for all processes
       copy: 
         dest: /etc/systemd/system.conf.d/60-DefaultLimitNOFILE.conf

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -97,7 +97,7 @@
       shell: "R -e \"install.packages('BiocManager')\""
 
     - name: Update file access limits for all processes
-      copy: 
+      copy:
         dest: /etc/systemd/system.conf.d/60-DefaultLimitNOFILE.conf
         content: |
           [Manager]


### PR DESCRIPTION
…applies to processes not started through PAM.  More details in SC-318.

This PR reverts the earlier approach.

