### PR TITLE
SC-318 create missing directory

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -96,6 +96,11 @@
     - name: Install BiocManager
       shell: "R -e \"install.packages('BiocManager')\""
 
+    - name: Create directory for the following step
+      file:
+        path: /etc/systemd/system.conf.d
+        state: directory
+
     - name: Update file access limits for all processes
       copy:
         dest: /etc/systemd/system.conf.d/60-DefaultLimitNOFILE.conf


### PR DESCRIPTION
The previous change failed because we were trying to create a file in a non-existent directory. This PR adds a step preceding the file creation which creates the directory.
