### PR TITLE
Update packer version

### DIFF
--- a/install_packer.sh
+++ b/install_packer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 workdir=/tmp/packer
-pversion=1.4.3
+pversion=1.4.4
 
 which packer || {
   mkdir -p $workdir


### PR DESCRIPTION
Something changed in the amazon-ebs builder[1] that prevents credentials from being passed
to packer correctly.  A packer update seems to fix the problem.

[1] https://www.packer.io/plugins/builders/amazon#specifying-amazon-credentials
