### PR TITLE
Fix rstudio too many redirects

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -103,8 +103,7 @@
       copy:
         dest: /etc/rstudio/rserver.conf
         content: |
-          www-address=127.0.0.1  #Only serve on internal interface
-          www-port=8787
+          auth-none=1
 
     - name: Replace rstudio-server service with no auth
       copy:

--- a/src/rstudio-server.service
+++ b/src/rstudio-server.service
@@ -6,11 +6,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 Environment="USER=ubuntu"
-PIDFile=/var/run/rstudio-server.pid
-User=ubuntu
+PIDFile=/run/rstudio-server.pid
 ExecStart=/usr/lib/rstudio-server/bin/rserver
-ExecStop=/usr/bin/killall -TERM rserver
-KillMode=none
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]

--- a/src/rstudio-server.service
+++ b/src/rstudio-server.service
@@ -5,9 +5,10 @@ Wants=network-online.target
 
 [Service]
 Type=forking
+Environment="USER=ubuntu"
 PIDFile=/var/run/rstudio-server.pid
 User=ubuntu
-ExecStart=/usr/lib/rstudio-server/bin/rserver --auth-none 1
+ExecStart=/usr/lib/rstudio-server/bin/rserver
 ExecStop=/usr/bin/killall -TERM rserver
 KillMode=none
 Restart=on-failure


### PR DESCRIPTION
Rstudio server on ubuntu 22.04 fails with `ERR_TOO_MANY_REDIRECTS`. The fix is to bypass the login page by setting some undocumented configurations[1].

[1] https://github.com/rstudio/rstudio/issues/1663#issuecomment-1603195799
