### PR TITLE
SC-383: Install R from posit

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -71,12 +71,19 @@
           - python3
           - python3-venv
           - python3-boto3
+          - gdebi-core
+          - libopenblas-dev
+          - libopenblas-pthread-dev
+          - libopenblas0
+          - libopenblas0-pthread
 
-    - name: Setup apt repo for R 4.3
+    - name: Setup R 4.3
       shell: |
-        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
-        add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40"
-        apt install --no-install-recommends r-base r-base-dev
+        export R_VERSION=4.3.1
+        curl -O https://cdn.rstudio.com/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
+        gdebi r-${R_VERSION}_1_amd64.deb
+        ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
+        ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
 
     # Install essential R packages
 


### PR DESCRIPTION
For some reason, Ubuntu does not like the .list downloaded from r-project (it worked fine on 18.04, but I can repro the error in GHA on U22.04 instance). Switching to posit (I successfully installed R/4.3.1 using https://docs.posit.co/resources/install-r/ ).
