### PR TITLE
SC-383: Fix rstudio config + proxypassreverse

### DIFF
--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -12,11 +12,11 @@
   RewriteCond %{HTTP:Upgrade} !=websocket
   RewriteRule /EC2_INSTANCE_ID/(.*)     http://localhost:8787/$1 [P,L]
 
-  <LocationMatch /EC2_INSTANCE_ID/>
+  <Location /EC2_INSTANCE_ID/ >
     AddHandler mod_python .py
     PythonPath "sys.path+['/usr/lib/cgi-bin']"
     PythonHeaderParserHandler access
     ProxyPass http://localhost:8787/
-    ProxyPassReverse http://localhost:8787/$0
-  </LocationMatch>
+    ProxyPassReverse /
+  </Location>
 </VirtualHost>

--- a/src/rstudio-server.service
+++ b/src/rstudio-server.service
@@ -5,11 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/rstudio-server.pid
-User=ubuntu
+PIDFile=/run/rstudio-server.pid
+Environment="USER=ubuntu"
 ExecStart=/usr/lib/rstudio-server/bin/rserver --auth-none 1
 ExecStop=/usr/bin/killall -TERM rserver
-KillMode=none
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=group
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This PR fixes the configuration for RStudio Server and more importantly the ProxyPassReverse to handle the redirect that we're seeing in RStudio (kudos to @brucehoff for solving the problem).
