### PR TITLE
SC-383: Temp R4.3 RStudio 524

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -17,6 +17,7 @@
           - dpkg-sig
           - expect
           - fakeroot
+          - gdebi-core
           - git
           - gnupg1
           - jq
@@ -71,11 +72,17 @@
           - python3
           - python3-venv
           - python3-boto3
-          - r-base
-          - r-base-dev
+
+    # Install R (see https://docs.posit.co/resources/install-r/)
+    - name: Install R 4.3.1
+      shell: |
+        export R_VERSION=4.3.1
+        curl -O https://cdn.rstudio.com/r/ubuntu-2204/pkgs/r-${R_VERSION}_1_amd64.deb
+        gdebi -n r-${R_VERSION}_1_amd64.deb
+        ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
+        ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
 
     # Install essential R packages
-
     - name: Install synapser
       # environment variable needed to communicate with the embedded python and install boto3 dependency
       shell: "R -e \"Sys.setenv(SYNAPSE_PYTHON_CLIENT_EXTRAS='boto3'); install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'), Ncpus = 2)\""
@@ -102,10 +109,12 @@
           DefaultLimitNOFILE=1000000
 
     - name: Download RStudio Server
-      get_url: url=https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-2022.02.3-492-amd64.deb dest=/tmp/rstudio.deb
+      get_url: url=https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-2023.06.1-524-amd64.deb dest=/tmp/rstudio.deb
 
     - name: Install RStudio Server
-      command: dpkg -i /tmp/rstudio.deb
+      command: |
+        export DEBIAN_FRONTEND=noninteractive
+        dpkg -i /tmp/rstudio.deb
 
     - name: Overwrite rstudio web config
       copy:

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -13,9 +13,6 @@
   RewriteRule /EC2_INSTANCE_ID/(.*)     http://localhost:8787/$1 [P,L]
 
   <Location /EC2_INSTANCE_ID/ >
-    AddHandler mod_python .py
-    PythonPath "sys.path+['/usr/lib/cgi-bin']"
-    PythonHeaderParserHandler access
     ProxyPass http://localhost:8787/
     ProxyPassReverse /
   </Location>


### PR DESCRIPTION
This PR updates R to 4.3.1 and RStudio to 524 on top of Ubuntu 2022.04. It also removes the mod_python from the apache config (i.e. no check on user). The goal is to verify that it does not hang while building (in the R install step with gdebi and in the RStudio step with dpkg).
