### PR TITLE
SC-383: Fix build - Use shell

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -112,7 +112,7 @@
       get_url: url=https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-2023.06.1-524-amd64.deb dest=/tmp/rstudio.deb
 
     - name: Install RStudio Server
-      command: |
+      shell: |
         export DEBIAN_FRONTEND=noninteractive
         dpkg -i /tmp/rstudio.deb
 


### PR DESCRIPTION
This PR should fix the build failure caused by https://github.com/Sage-Bionetworks-IT/packer-rstudio/pull/76 .
