### PR TITLE
SC-383: Support extra minor

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: aws-deploy
 on:
   push:
     branches: [ '*' ]
-    tags: [ 'v[0-9]+\.[0-9]+\.[0-9]+' ]
+    tags: [ 'v[0-9]+\.[0-9]+\.[0-9]+\.*[0-9]*' ]
   pull_request:
     branches: [ '*' ]
 


### PR DESCRIPTION
Build tag'ed as 2.3.1.1 did not start because the extra '.1' was not covered. Adding the option.
