### PR TITLE
SC-383: Install python synapse client

### DIFF
--- a/src/access.py
+++ b/src/access.py
@@ -16,13 +16,16 @@ ssm_parameter_name_env_var = 'SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME'
 kms_alias_env_var = 'KMS_KEY_ALIAS'
 
 def headerparserhandler(req):
+  req.log_error("Entering handler")
   jwt_str = req.headers_in['x-amzn-oidc-data'] #proxy.conf ensures this header exists
 
   try:
     payload = jwt_payload(jwt_str)
+    req.log_error("Got JWT payload")
 
     if payload['userid'] == approved_user() and payload['exp'] > time.time():
       store_to_ssm(req.headers_in['x-amzn-oidc-accesstoken'])
+      req.log_error("Saved access token")
       return apache.OK
     else:
       return apache.HTTP_UNAUTHORIZED #the userid claim does not match the userid tag

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -73,6 +73,10 @@
           - python3-venv
           - python3-boto3
 
+    # Install python synapse client
+    - name: Install Python Synapse client
+      command: pip3 install synapseclient
+
     # Install R (see https://docs.posit.co/resources/install-r/)
     - name: Install R 4.3.1
       shell: |


### PR DESCRIPTION
This PR installs the python synapseclient prior to installing synapser. This seems to fix a problem where synapser appears installed but subsequently attempts to install when 'library(synpaser)' is executed (and fails).
