### PR TITLE
[SC-383] Fix apache reverse proxy

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -53,7 +53,6 @@
           - zlib1g-dev
           - apache2
           - apache2-dev
-          - libapache2-mod-python
           - flex
           - ssl-cert
           - libxml2-dev
@@ -72,6 +71,28 @@
           - python3
           - python3-venv
           - python3-boto3
+          - python-is-python3
+
+    # The mod_python provided by apt in Ubuntu 22.04 intermittently fails with segmentation faults.
+    # mod_python is only supported from master branch at https://github.com/grisha/mod_python.git
+    # Compiling requires: 'flex' and 'apache2-dev' from installed from apt, which should have been installed in the previous steps
+    - name: Clone git repository for Apache Python Module - mod_python
+      ansible.builtin.git:
+        repo: 'https://github.com/grisha/mod_python.git'
+        # latest commit of the master branch that I've verified compilable as of the writing of this script (ver 3.5.0.1)
+        version: 9db86bca5106b5cf7ceca7645ec0208446c71e25
+        dest: /tmp/mod_python_source
+
+    - name: Compile and install mod_python
+      shell:
+        cmd: |
+          ./configure
+
+          make install
+
+          # add mod_python as an available module to enable later
+          echo 'LoadModule python_module /usr/lib/apache2/modules/mod_python.so' >> /etc/apache2/mods-available/python.load
+        chdir: /tmp/mod_python_source
 
     # Install python synapse client
     - name: Install Python Synapse client

--- a/src/proxy.conf
+++ b/src/proxy.conf
@@ -12,8 +12,11 @@
   RewriteCond %{HTTP:Upgrade} !=websocket
   RewriteRule /EC2_INSTANCE_ID/(.*)     http://localhost:8787/$1 [P,L]
 
-  <Location /EC2_INSTANCE_ID/ >
+  <LocationMatch /EC2_INSTANCE_ID/ >
+    AddHandler mod_python .py
+    PythonPath "sys.path+['/usr/lib/cgi-bin']"
+    PythonHeaderParserHandler access
     ProxyPass http://localhost:8787/
-    ProxyPassReverse /
-  </Location>
+    ProxyPassReverse http://localhost:8787/$0
+  </LocationMatch>
 </VirtualHost>


### PR DESCRIPTION
The mod_python module from the apt repository does not work.  We see the following errors intermittently..

```
[core:notice] [pid 483:tid 139833953666944] AH00051: child pid 10471 exit signal Segmentation fault (11), possible coredump in /etc/apache2
```

The version of mod_python built from master of https://github.com/grisha/mod_python seems to work reliably.  The doc indicates that mod_python is only supported from the master branch of the repo going forward.

