### PR TITLE
SC-383: Force lib path to what it should already be

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -107,19 +107,19 @@
     - name: Install synapser
       become_user: ubuntu
       # environment variable needed to communicate with the embedded python and install boto3 dependency
-      shell: "R -e \"Sys.setenv(SYNAPSE_PYTHON_CLIENT_EXTRAS='boto3'); install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'), Ncpus = 2)\""
+      shell: "R -e \"Sys.setenv(SYNAPSE_PYTHON_CLIENT_EXTRAS='boto3'); install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'), Ncpus = 2, lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
     - name: Install tidyverse
       become_user: ubuntu
-      shell: "R -e \"install.packages('tidyverse', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'))\""
+      shell: "R -e \"install.packages('tidyverse', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
     - name: Install devtools
       become_user: ubuntu
-      shell: "R -e \"install.packages('devtools', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'))\""
+      shell: "R -e \"install.packages('devtools', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
     - name: Install BiocManager
       become_user: ubuntu
-      shell: "R -e \"install.packages('BiocManager', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'))\""
+      shell: "R -e \"install.packages('BiocManager', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
     - name: Create directory for the following step
       file:


### PR DESCRIPTION
The build failed because we attempted to deploy to /opt/R/xxx as ubuntu. No idea why it did that, it should have deployed to /home/ubuntu/R/xxx. This PR specifies the lib path in the install.packages call. I removed the packages on my instance, then re-installed them successfully as ubuntu using the commands in the playbook (the only difference is that their dependencies are in /opt/R since they were installed as root).
