### PR TITLE
SC-383: tweaks

### DIFF
--- a/src/access.py
+++ b/src/access.py
@@ -16,16 +16,13 @@ ssm_parameter_name_env_var = 'SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME'
 kms_alias_env_var = 'KMS_KEY_ALIAS'
 
 def headerparserhandler(req):
-  req.log_error("Entering handler")
   jwt_str = req.headers_in['x-amzn-oidc-data'] #proxy.conf ensures this header exists
 
   try:
     payload = jwt_payload(jwt_str)
-    req.log_error("Got JWT payload")
 
     if payload['userid'] == approved_user() and payload['exp'] > time.time():
       store_to_ssm(req.headers_in['x-amzn-oidc-accesstoken'])
-      req.log_error("Saved access token")
       return apache.OK
     else:
       return apache.HTTP_UNAUTHORIZED #the userid claim does not match the userid tag

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -127,7 +127,7 @@
       become_user: ubuntu
       shell: "R -e \"install.packages('BiocManager', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
-    - name: Install BiocManager
+    - name: Install arrow
       become_user: ubuntu
       shell: "R -e \"install.packages('arrow', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -109,6 +109,15 @@
         path: /home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3
         state: directory
 
+    - name: Install devtools
+      become_user: ubuntu
+      shell: "R -e \"install.packages('devtools', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
+
+    # Install reticulate first
+    - name: Install reticulate 1.28
+      become_user: ubuntu
+      shell: "R -e \"devtools::install_version('reticulate', version='1.28', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'))\""
+
     # Install essential R packages
     - name: Install synapser
       become_user: ubuntu
@@ -118,10 +127,6 @@
     - name: Install tidyverse
       become_user: ubuntu
       shell: "R -e \"install.packages('tidyverse', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
-
-    - name: Install devtools
-      become_user: ubuntu
-      shell: "R -e \"install.packages('devtools', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
     - name: Install BiocManager
       become_user: ubuntu

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -127,6 +127,10 @@
       become_user: ubuntu
       shell: "R -e \"install.packages('BiocManager', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
 
+    - name: Install BiocManager
+      become_user: ubuntu
+      shell: "R -e \"install.packages('arrow', repos=c('https://packagemanager.posit.co/cran/__linux__/jammy/latest'), lib=c('/home/ubuntu/R/x86_64-pc-linux-gnu-library/4.3/'))\""
+
     - name: Create directory for the following step
       file:
         path: /etc/systemd/system.conf.d


### PR DESCRIPTION
This PR removes logging from access.py and installs the R package 'arrow' as discussed on Slack.
Note: 'readtext' is not installed because one of its dependencies triggered a warning to reboot to replace the kernel (if it does that during the build it will timeout). There are alternatives to this package so should be fine.
